### PR TITLE
Target Option: last 3 elevation digits

### DIFF
--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -27,6 +27,7 @@
         "showAnimations": "Use Large Icons",
         "copyTarget": "Auto-copy Target to clipboard",
         "lowAndHigh": "Show both Low and High angles",
+        "lastDigits": "Compact target display (last 3 elevation digits)",
         "showBearing": "Bearing",
         "showDistance": "Distance",
         "showTimeOfFlight": "Time of Flight",

--- a/public/locales/en/tooltips.json
+++ b/public/locales/en/tooltips.json
@@ -34,6 +34,7 @@
     "performanceWarning": "Can cause performance issues",
     "markerDragTooltip": "Display grid while dragging",
     "copyNextFlagsTooltip": "When clicking a flag, automatically add the next flags to clipboard",
+    "lastDigitsTooltip": "Show compact target mode: only 3 elevation digits (e.g. 193, nor 1193)",
     "copyTargetTooltip": "After placing/dragging a target, automatically copy the calculations to clipboard",
     "lowAndHighTooltip": "Show both high and low angle for weapons that can shoot in both modes",
     "capZoneOnHoverTooltip": "Instead of showing capzones at all times, only show them when hovering over a flag",

--- a/src/components/dialogs/settings.html
+++ b/src/components/dialogs/settings.html
@@ -359,6 +359,22 @@
           </tr>
 
           <tr>
+            <td>
+                <label class="mcui-checkbox">
+                  <input id="lastDigitsSetting" type="checkbox">
+                  <span>
+                    <svg class="mcui-check" viewBox="-2 -2 35 35" aria-hidden="true">
+                      <polyline points="7.57 15.87 12.62 21.07 23.43 9.93" />
+                    </svg>
+                  </span>
+                </label>
+            </td>
+            <td>
+              <span data-i18n="settings:lastDigits" class="toggleCheckbox"></span>
+            </td>
+          </tr>
+
+          <tr>
               <td>
                   <label class="mcui-checkbox">
                       <input id="spreadRadiusSetting" type="checkbox">

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -95,6 +95,9 @@ export function loadSettings(){
 
     App.userSettings.lowAndHigh = loadLocalSetting("settings-low-high", 0);
     $("#lowAndHighSetting").prop("checked", App.userSettings.lowAndHigh);
+
+    App.userSettings.lastDigits = loadLocalSetting("settings-last-digits", 0);
+    $("#lastDigitsSetting").prop("checked", App.userSettings.lastDigits);
     
     App.userSettings.copyTarget = loadLocalSetting("settings-copy-target", 0);
     $("#targetCopySetting").prop("checked", App.userSettings.copyTarget);
@@ -486,6 +489,13 @@ $("#lowAndHighSetting").on("change", function() {
     var val =  $("#lowAndHighSetting").is(":checked");
     App.userSettings.lowAndHigh = val;
     localStorage.setItem("settings-low-high", +val);
+    App.minimap.updateTargets();
+});
+
+$("#lastDigitsSetting").on("change", function() {
+    var val =  $("#lastDigitsSetting").is(":checked");
+    App.userSettings.lastDigits = val;
+    localStorage.setItem("settings-last-digits", +val);
     App.minimap.updateTargets();
 });
 

--- a/src/js/squadTargetMarker.js
+++ b/src/js/squadTargetMarker.js
@@ -249,7 +249,14 @@ export const squadTargetMarker = squadMarker.extend({
             [elevation, timeOfFlight] = formatElevationData(selectedElevation, selectedTimeOfFlight);
         }
 
-        let content = `<span class=calcNumber></span></br><span>${elevation}</span>`;
+        let content;
+        
+        // Checks if last three elevation digits option is enabled and if selected weapon is "Mortar"
+        if (App.userSettings.lastDigits && ["Mortar"].includes(App.activeWeapon.name)){
+            content = `<span class=calcNumber></span></br><span>${elevation.toString().slice(-3)}</span>`;
+        } else {
+           content = `<span class=calcNumber></span></br><span>${elevation}</span>`;
+        }
 
         if (App.userSettings.showBearing) content += `<br><span class=bearingUiCalc>${BEARING.toFixed(1)}<span data-i18n="common:°">${i18next.t("common:°")}</span></span>`;
         if (App.userSettings.showTimeOfFlight) content += `<br><span class=bearingUiCalc>${timeOfFlight}</span>`;

--- a/src/js/tooltips.js
+++ b/src/js/tooltips.js
@@ -150,6 +150,15 @@ tippy("span[data-i18n='settings:copyTarget']", {
     },
 });
 
+tippy("span[data-i18n='settings:lastDigits']", {
+    ...commonToolipsSettings,
+    onShow(tip) {
+        tip.setContent(`
+            ${i18next.t("tooltips:lastDigitsTooltip")}
+        `);
+    },
+});
+
 tippy("span[data-i18n='settings:capZoneOnHover']", {
     ...commonToolipsSettings,
     onShow(tip) {


### PR DESCRIPTION
New target option: last 3 elevation digits as were discussed in #386 

Makes info about target more minimized.

Checks if current selected weapon is "Mortar" type and Target Option "Last 3 digits" selected. If selected weapon isn't "Mortar" then do nothing to elevation value.

The working example:

![lastDigitsFeature](https://github.com/user-attachments/assets/608c9753-47c1-4d0b-a54c-ab3c65eae8bb)
