### PR TITLE
fix: resolve 404 error for mortarIcon marker

### DIFF
--- a/src/js/squadIcon.js
+++ b/src/js/squadIcon.js
@@ -1,7 +1,7 @@
 import { Icon } from "leaflet";
 
 export const mortarIcon = new Icon({
-    iconUrl: "../img/markers/weapons/marker_mortar.webp",
+    iconUrl: "../img/markers/weapons/marker_mortar_1.webp",
     shadowUrl: "/img/markers/weapons/marker_shadow.webp",
     iconSize:     [38, 47], 
     shadowSize:   [38, 47], 


### PR DESCRIPTION
## Summary
Fixes #273 - Leaflet was throwing 404 errors because `mortarIcon` referenced `marker_mortar.webp` which does not exist in the repository.

## Changes
Changed `mortarIcon` iconUrl from `marker_mortar.webp` to `marker_mortar_1.webp` which exists.

## Testing
- Verified no 404 errors in browser Network tab when adding weapons to the map