### PR TITLE
Add optional free point selection to lane prediction

### DIFF
--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -35,6 +35,7 @@
         "showTimeOfFlight": "Time of Flight",
         "showHeightDiff": "Height Difference",
     "LaneFinderOptions": "Layers Options", 
+        "freePointSelection": "Allow selecting points in any order",
         "capZoneOnHover": "Only show capzones when hovering",
         "revealLayerOnHover" : "Reveal layer when hovering a flag",
         "circlesFlags": "Show Flags as circles",

--- a/src/components/dialogs/settings.html
+++ b/src/components/dialogs/settings.html
@@ -557,6 +557,22 @@
           <tr>
             <td>
                 <label class="mcui-checkbox">
+                  <input id="freePointSelectionSettings" type="checkbox">
+                  <span>
+                    <svg class="mcui-check" viewBox="-2 -2 35 35" aria-hidden="true">
+                      <polyline points="7.57 15.87 12.62 21.07 23.43 9.93" />
+                    </svg>
+                  </span>
+                </label>
+            </td>
+            <td>
+              <span data-i18n="settings:freePointSelection" class="toggleCheckbox"></span>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+                <label class="mcui-checkbox">
                   <input id="showMainZonesSettings" type="checkbox">
                   <span>
                     <svg class="mcui-check" viewBox="-2 -2 35 35" aria-hidden="true">

--- a/src/js/squadLaneSolver.js
+++ b/src/js/squadLaneSolver.js
@@ -1,0 +1,216 @@
+/**
+ * Squad Lane Solver
+ *
+ * Works out which capture points are still possible on a randomized layer
+ * (RAAS, RVAAS, Invasion, RINV), at which depth, and with what probability.
+ *
+ * A randomized layer picks one route from main to main, then one point per
+ * cluster along that route:
+ *
+ *     route   = ordered list of clusters (one lane, main to main)
+ *     cluster = one step on the route, holding N candidate points
+ *     step    = 1-based index along the route. This is the number drawn on the flag.
+ *
+ * A confirmed point is a constraint. It removes every route that cannot carry the
+ * point and locks the cluster that can. Constraints are unordered, so any point in
+ * the chain can be confirmed, not only the next one.
+ *
+ * Points are identified by objectName ("C4-BridgeviewApartments"), which is unique
+ * inside a layer. The name field is not: 16 of 42 layers checked reuse a display
+ * name for two unrelated locations. One flag can own several ids when the randomizer
+ * offers the same location on more than one route or at more than one depth, so a
+ * constraint holds a set of ids and any one of them satisfies it.
+ *
+ * No Leaflet, no DOM, no App singleton. Reads layerData only.
+ */
+
+/** Cap on route enumeration. Most layers stay under 10 routes. Largest seen is 260 (Manicouagan RAAS v2). */
+const MAX_ROUTES = 2000;
+
+export default class SquadLaneSolver {
+
+    /**
+     * @param {object} layerData - raw layer payload from /get/layer
+     */
+    constructor(layerData) {
+        this.routes = [];
+        this.truncated = false;
+        this.ok = false;
+
+        // Node ids of the mains the routes run between. start is the main the links
+        // point away from, which is Team 1's main in every layer checked.
+        this.start = null;
+        this.end = null;
+        this._build(layerData);
+    }
+
+    /**
+     * Enumerate every simple route from the start main to the end main.
+     * @param {object} layerData
+     */
+    _build(layerData) {
+        const capturePoints = layerData?.capturePoints;
+        if (!capturePoints || !layerData.objectives) return;
+
+        // Links are stored in lanes on some layers and in clusters on others.
+        const links = capturePoints.lanes?.links?.length
+            ? capturePoints.lanes.links
+            : capturePoints.clusters?.links;
+        if (!links?.length) return;
+
+        // Links refer to mains by objectDisplayName and to clusters by name.
+        const byNode = {};
+        Object.values(layerData.objectives).forEach((objective) => {
+            byNode[objective.name === "Main" ? objective.objectDisplayName : objective.name] = objective;
+        });
+
+        const adjacency = new Map();
+        const hasIncoming = new Set();
+        const hasOutgoing = new Set();
+        links.forEach((link) => {
+            if (!adjacency.has(link.nodeA)) adjacency.set(link.nodeA, []);
+            adjacency.get(link.nodeA).push(link.nodeB);
+            hasOutgoing.add(link.nodeA);
+            hasIncoming.add(link.nodeB);
+        });
+
+        const nodes = new Set([...hasOutgoing, ...hasIncoming]);
+        const start = [...nodes].find((n) => !hasIncoming.has(n));
+        const end = [...nodes].find((n) => !hasOutgoing.has(n));
+        if (!start || !end) return;
+        this.start = start;
+        this.end = end;
+
+        const found = [];
+        const walk = (node, trail) => {
+            if (found.length >= MAX_ROUTES) { this.truncated = true; return; }
+            if (node === end) { found.push(trail.slice()); return; }
+            for (const next of (adjacency.get(node) || [])) {
+                if (trail.includes(next)) continue;
+                trail.push(next);
+                walk(next, trail);
+                trail.pop();
+                if (this.truncated) return;
+            }
+        };
+        walk(start, [start]);
+
+        // Drop the mains, they carry no candidates.
+        this.routes = found
+            .map((route) => route
+                .map((node) => byNode[node])
+                .filter((objective) => objective?.points?.length)
+                .map((cluster) => ({
+                    cluster: cluster.name,
+                    pos: cluster.pointPosition,
+                    ids: cluster.points.map((point) => point.objectName),
+                })))
+            .filter((route) => route.length);
+
+        this.ok = this.routes.length > 0;
+
+        // Depth of the last capture point. Every route in a layer has the same length in
+        // the data checked, so this is also the step before the far main.
+        this.stepCount = this.ok ? Math.max(...this.routes.map((route) => route.length)) : 0;
+    }
+
+    /**
+     * Every candidate id in the layer, unconstrained.
+     * @returns {Set<string>}
+     */
+    allIds() {
+        const ids = new Set();
+        this.routes.forEach((route) => route.forEach((step) => step.ids.forEach((id) => ids.add(id))));
+        return ids;
+    }
+
+    /**
+     * Resolve the layer against a set of confirmations.
+     *
+     * @param {{ids: string[], step: ?number}[]} constraints - one entry per confirmed flag.
+     *        ids are the candidate slots the flag owns, and any one of them satisfies it.
+     *        step pins the flag to that depth. Confirming a point means "this is my Nth
+     *        point", so routes carrying it at another depth are removed.
+     * @param {boolean} [fromEnd] - number the steps from the end main instead of the start
+     *                              main, so depths read from the side the user plays
+     * @returns {{alive: number, total: number, steps: Map<number, Map<string, number>>,
+     *            byId: Map<string, {steps: Set<number>, probability: number}>, impossible: boolean}}
+     */
+    solve(constraints = [], fromEnd = false) {
+        const survivors = [];
+
+        for (const route of this.routes) {
+            const locks = new Map();      // step index -> the id that must sit there
+            const hitsPerConstraint = [];
+            let viable = true;
+
+            for (const constraint of constraints) {
+                const ids = constraint.ids;
+                const pinned = constraint.step ?? null;
+                const hits = [];
+                route.forEach((step, index) => {
+                    if (pinned !== null && (fromEnd ? route.length - index : index + 1) !== pinned) return;
+                    const overlap = step.ids.filter((id) => ids.includes(id));
+                    if (overlap.length) hits.push({ index, overlap });
+                });
+
+                // This route cannot carry the flag at all.
+                if (!hits.length) { viable = false; break; }
+
+                // Only one cluster on this route can hold it, and only one way. Lock it.
+                if (hits.length === 1 && hits[0].overlap.length === 1) {
+                    const { index, overlap } = hits[0];
+                    if (locks.has(index) && locks.get(index) !== overlap[0]) { viable = false; break; }
+                    locks.set(index, overlap[0]);
+                }
+                hitsPerConstraint.push(hits.map((h) => h.index));
+            }
+
+            // Two flags cannot share a step. If two constraints both come down to the same
+            // single cluster the route is impossible, even when neither of them locked
+            // (each had several candidates in that cluster).
+            if (viable) {
+                for (let a = 0; a < hitsPerConstraint.length && viable; a++) {
+                    if (hitsPerConstraint[a].length !== 1) continue;
+                    for (let b = a + 1; b < hitsPerConstraint.length; b++) {
+                        if (hitsPerConstraint[b].length !== 1) continue;
+                        if (hitsPerConstraint[a][0] === hitsPerConstraint[b][0]) { viable = false; break; }
+                    }
+                }
+            }
+
+            if (viable) survivors.push({ route, locks });
+        }
+
+        const steps = new Map();
+        const byId = new Map();
+        const routeWeight = survivors.length ? 1 / survivors.length : 0;
+
+        survivors.forEach(({ route, locks }) => {
+            route.forEach((step, index) => {
+                const ids = locks.has(index) ? [locks.get(index)] : step.ids;
+                const share = routeWeight / ids.length;
+                const stepNumber = fromEnd ? route.length - index : index + 1;
+
+                if (!steps.has(stepNumber)) steps.set(stepNumber, new Map());
+                const atStep = steps.get(stepNumber);
+
+                ids.forEach((id) => {
+                    atStep.set(id, (atStep.get(id) || 0) + share);
+                    let entry = byId.get(id);
+                    if (!entry) { entry = { steps: new Set(), probability: 0 }; byId.set(id, entry); }
+                    entry.steps.add(stepNumber);
+                    entry.probability += share;
+                });
+            });
+        });
+
+        return {
+            alive: survivors.length,
+            total: this.routes.length,
+            steps,
+            byId,
+            impossible: constraints.length > 0 && survivors.length === 0,
+        };
+    }
+}

--- a/src/js/squadLayer.js
+++ b/src/js/squadLayer.js
@@ -921,27 +921,26 @@ export default class SquadLayer {
                 this.countFromEnd = flag === this._mainForNode(this.solver.end);
                 this._renderFromSolver();
             }
-        } else {
-            const pinnedAt = this.confirmedStep.get(flag);
-
-            if (pinnedAt == null) {
-                const step = this._stepForClick(flag);
-                if (step == null) {
-                    console.debug(`[LAYER] ${flag.name} cannot be confirmed right now, ignoring`);
-                    return false;
-                }
-                this.selectedFlags.push(flag);
-                this.confirmedStep.set(flag, step);
-            } else if (App.userSettings.freePointSelection) {
-                // Clicking a confirmed point removes it.
-                this._release(flag);
-            } else {
-                // Ordered mode walks back down the chain: releasing a point also releases
-                // everything confirmed after it.
-                this.selectedFlags
-                    .filter((other) => (this.confirmedStep.get(other) ?? 0) >= pinnedAt)
-                    .forEach((other) => this._release(other));
+        } else if (!this.selectedFlags.includes(flag)) {
+            const confirmation = this._confirmationFor(flag);
+            if (!confirmation) {
+                console.debug(`[LAYER] ${flag.name} cannot be confirmed right now, ignoring`);
+                return false;
             }
+            this.selectedFlags.push(flag);
+            this.confirmedStep.set(flag, confirmation.step);
+            this._renderFromSolver();
+        } else if (App.userSettings.freePointSelection) {
+            // Clicking a confirmed point removes it.
+            this._release(flag);
+            this._renderFromSolver();
+        } else {
+            // Ordered mode walks back down the chain: releasing a point also releases
+            // everything confirmed after it.
+            const pinnedAt = this.confirmedStep.get(flag);
+            this.selectedFlags
+                .filter((other) => (this.confirmedStep.get(other) ?? 0) >= pinnedAt)
+                .forEach((other) => this._release(other));
             this._renderFromSolver();
         }
 
@@ -987,18 +986,23 @@ export default class SquadLayer {
 
 
     /**
-     * Depth a click would confirm this flag at, or null if it cannot be confirmed now.
+     * What a click would confirm about this flag, or null if it cannot be confirmed now.
      *
-     * Ordered mode, the default, only accepts the next point in the chain. With free
-     * selection on, any still-possible point can be confirmed at the shallowest depth it
-     * can occupy. Confirming the points before it pins it deeper.
+     * A point that could still sit at the next open depth is pinned there, which is the
+     * user saying "this is my next point". A point further along is confirmed without a
+     * depth: all it says is that the point is on the route. Pinning it to its shallowest
+     * depth would silently discard the routes carrying it deeper, and those are often the
+     * majority. Its depth resolves once the points before it are confirmed.
+     *
+     * Ordered mode only accepts the next point, so it never confirms without a depth.
      * @param {SquadObjective} flag
-     * @returns {?number}
+     * @returns {?{step: ?number}}
      */
-    _stepForClick(flag) {
+    _confirmationFor(flag) {
         const options = this._stepOptionsFor(flag);
-        if (App.userSettings.freePointSelection) return options[0] ?? null;
-        return options.includes(this.nextStep) ? this.nextStep : null;
+        if (!options.length) return null;
+        if (options.includes(this.nextStep)) return { step: this.nextStep };
+        return App.userSettings.freePointSelection ? { step: null } : null;
     }
 
 
@@ -1028,9 +1032,9 @@ export default class SquadLayer {
 
         if (previewFlag) {
             // Preview what clicking would do, including the depth it would pin.
-            const step = this._stepForClick(previewFlag);
-            if (step == null) return;
-            constraints.push({ ids: previewFlag.candidateIds, step });
+            const confirmation = this._confirmationFor(previewFlag);
+            if (!confirmation) return;
+            constraints.push({ ids: previewFlag.candidateIds, step: confirmation.step });
         }
 
         const result = this.solver.solve(constraints, this.countFromEnd);
@@ -1039,10 +1043,11 @@ export default class SquadLayer {
         this.solverResult = result;
 
         // Shallowest step not yet pinned. Flags that can fill it are marked "next".
-        const confirmedSteps = new Set();
-        this.selectedFlags.forEach((flag) => flag.solverSteps().forEach((step) => confirmedSteps.add(step)));
+        // Confirmations without a depth do not take a slot, since which one they fill
+        // is still open.
+        const pinned = new Set([...this.confirmedStep.values()].filter((step) => step != null));
         let nextStep = 1;
-        while (confirmedSteps.has(nextStep)) nextStep++;
+        while (pinned.has(nextStep)) nextStep++;
         this.nextStep = nextStep;
 
         this.flags.forEach((flag) => flag.applySolverResult(previewFlag !== null));
@@ -1078,9 +1083,11 @@ export default class SquadLayer {
         this.pathLines.forEach((line) => line.removeFrom(this.activeLayerMarkers).remove());
         this.pathLines = [];
 
+        // A confirmed point whose depth is still open has no place in the chain yet.
         const points = this.selectedFlags
-            .map((flag) => ({ step: flag.solverSteps()[0], latlng: flag.latlng }))
-            .filter((point) => point.step != null)
+            .map((flag) => ({ steps: flag.solverSteps(), latlng: flag.latlng }))
+            .filter((point) => point.steps.length === 1)
+            .map((point) => ({ step: point.steps[0], latlng: point.latlng }))
             .sort((a, b) => a.step - b.step);
 
         // The mains bracket the chain. The one the numbering counts from sits one step

--- a/src/js/squadLayer.js
+++ b/src/js/squadLayer.js
@@ -9,6 +9,7 @@ import { Curve } from "./libs/leaflet-curve.js";
 import { squadSpawnGroup } from "./squadSpawnGroup.js";
 import { squadCameraActor } from "./squadCameraActor.js";
 import { SquadVehicleSpawner } from "./squadVehicleSpawner.js";
+import SquadLaneSolver from "./squadLaneSolver.js";
 
 export default class SquadLayer {
 
@@ -28,7 +29,6 @@ export default class SquadLayer {
 
         [this.offset_x, this.offset_y] = this.getLayerOffsets(this.layerData.mapTextureCorners);
         this.isVisible = true;
-        this.currentPosition = 0;
 
         // latlng's of the currently selected flags
         this.path = [];
@@ -44,12 +44,28 @@ export default class SquadLayer {
 
         if (!App.userSettings.showFlagsDistance) this.polyline.hideMeasurements();
 
-        // Currently selected flags
-        this.selectedFlags = [];
-        this.selectedReachableClusters = [];
+        // On randomized layers the chain is drawn as one polyline per run of adjacent
+        // confirmed points, so no line crosses a gap the user has not confirmed.
+        this.pathLines = [];
 
-        // Hold the availables clusters at all time
-        this.currentReachableClusters = new Set();
+        // Capture points the user has confirmed, in no particular order.
+        // See squadLaneSolver.js.
+        this.selectedFlags = [];
+
+        // Depth each confirmed flag is pinned to. A point that could sit at two depths is
+        // pinned to the shallowest one still open. Confirm the points before it to pin it
+        // deeper.
+        this.confirmedStep = new Map();
+
+        // Latest solver output, recalculated on every confirmation. SquadObjective reads
+        // it to decide what each flag shows and whether it is still possible.
+        this.solverResult = null;
+        this.nextStep = 1;
+
+        // Which main the depth numbers are counted from. Defaults to the main the routes
+        // start from.
+        this.perspectiveMain = null;
+        this.countFromEnd = false;
         this.mains = [];
         this.mainZones = {
             rectangles: [],
@@ -62,7 +78,6 @@ export default class SquadLayer {
         this.flags = [];
         this.hexs = [];
         this.stagingZones = [];
-        this.reversed = false;
 
         this.spawnGroups = [];
         this.vehicleSpawners = [];
@@ -84,8 +99,19 @@ export default class SquadLayer {
 
         this.mainZones.ammocrates = [];
 
-        this.init();
         this.isRandomized = this.isRandomized();
+
+        // Randomized layers are resolved from their route space instead of walked step by
+        // step, so the solver has to exist before the flags are drawn.
+        if (this.isRandomized) this.solver = new SquadLaneSolver(layerData);
+
+        this.init();
+
+        if (this.solver?.ok) {
+            this.perspectiveMain = this._mainForNode(this.solver.start);
+            this._renderFromSolver();
+        }
+        else if (this.isRandomized) console.debug("[LAYER] no usable route graph, lane prediction disabled");
 
         if (process.env.DISABLE_FACTIONS != "true") {
             this.factions = new SquadFactions(this, broadcast);
@@ -294,7 +320,7 @@ export default class SquadLayer {
                     if (this.areLatLngsClose(flag.latlng, latlng)) {
                         console.debug(`[LAYER] adding cluster ${objCluster.name} to flag ${flag.name}`);
                         console.debug("[LAYER] new clustersList: ", flag.clusters);
-                        flag.addCluster(objCluster);
+                        flag.addCluster(objCluster, obj);
                         flagExists = true;
                     }
                 });
@@ -310,17 +336,6 @@ export default class SquadLayer {
                 }
             });
         });
-
-        // Pre-select first main flag in invasion
-        if (this.gamemode === "Invasion" || this.gamemode === "RINV") {
-            this.mains.forEach((main) => {
-                // Invaders are always Team 1
-                if (main.objectName.toLowerCase().includes("team1")){
-                    this._handleFlagClick(main, false);
-                    return;
-                }
-            });
-        }
 
     }
 
@@ -881,173 +896,242 @@ export default class SquadLayer {
     }
 
 
+    /**
+     * Confirm or un-confirm a capture point.
+     *
+     * Confirmations are a set, not a sequence. With free selection on, any point on the
+     * map can be clicked, and clicking a confirmed point removes it. The solver
+     * recalculates everything from the whole set, so click order does not matter.
+     *
+     * @param {SquadObjective} flag - the clicked flag
+     * @param {boolean} broadcast - forward the click to the collaborative session
+     * @returns {boolean} true if the click changed anything
+     */
     _handleFlagClick(flag, broadcast = true) {
-        
-        let backward = false;
 
-        if (this.selectedFlags.length === 0){
-            this.startPosition = flag.position;
-            if (flag.position > 1){
-                this.reversed = true;
+        if (!this.solver?.ok) return false;
+
+        if (flag.isMain) {
+            // Mains are not capture points. Clicking one points the depth numbering at
+            // that side. Clicking the side already selected clears every confirmation.
+            if (flag === this.perspectiveMain) {
+                this._resetLayer();
+            } else {
+                this.perspectiveMain = flag;
+                this.countFromEnd = flag === this._mainForNode(this.solver.end);
+                this._renderFromSolver();
             }
-        }
+        } else {
+            const pinnedAt = this.confirmedStep.get(flag);
 
-        // If the clicked flag is in front of the current position, skip
-        if (Math.abs(this.startPosition - flag.position) > this.currentPosition) {
-
-            // In RAAS/RVAAS, we can click on the oposite main flag to reset the layer
-            if ((this.gamemode === "RAAS" || this.gamemode === "RVAAS") && flag.isMain){
-                if (broadcast && App.session.ws && App.session.ws.readyState === WebSocket.OPEN) {
-                    App.session.ws.send(
-                        JSON.stringify({
-                            type: "CLICK_LAYER",
-                            flag: flag.objectName,
-                            selectedFlags: [],
-                        })
-                    );
-                    console.debug(`[LAYER] Sent layer click update for flag #${flag.objectName}`);
+            if (pinnedAt == null) {
+                const step = this._stepForClick(flag);
+                if (step == null) {
+                    console.debug(`[LAYER] ${flag.name} cannot be confirmed right now, ignoring`);
+                    return false;
                 }
-
-                this._resetLayer();
-                this._handleFlagClick(flag, false);
-                return true;
+                this.selectedFlags.push(flag);
+                this.confirmedStep.set(flag, step);
+            } else if (App.userSettings.freePointSelection) {
+                // Clicking a confirmed point removes it.
+                this._release(flag);
+            } else {
+                // Ordered mode walks back down the chain: releasing a point also releases
+                // everything confirmed after it.
+                this.selectedFlags
+                    .filter((other) => (this.confirmedStep.get(other) ?? 0) >= pinnedAt)
+                    .forEach((other) => this._release(other));
             }
-
-            console.debug("[LAYER]   -> Clicked Flag is in front, skipping..");
-            return false; 
+            this._renderFromSolver();
         }
 
-        // Going backward
-        if (Math.abs(this.startPosition - flag.position)+1 <= this.currentPosition){
-
-            backward = true;
-            this.selectedReachableClusters.pop();
-
-            let positionToReduce = (this.currentPosition - Math.abs(this.startPosition - flag.position));
-            console.debug("[LAYER] # of Going backward : ", positionToReduce);
-
-            if (flag === this.selectedFlags[0]) {
-                console.debug("[LAYER] Can't unselect main flag");
-                if (broadcast && App.session.ws && App.session.ws.readyState === WebSocket.OPEN) {
-                    App.session.ws.send(
-                        JSON.stringify({
-                            type: "CLICK_LAYER",
-                            flag: flag.objectName,
-                            selectedFlags: [],
-                        })
-                    );
-                    console.debug(`[LAYER] Sent layer click update for flag #${flag.objectName}`);
-                }
-                this._resetLayer();
-                return;
-            }
-
-            if (flag.isMain && (this.gamemode != "Invasion" || this.gamemode != "RINV")){
-                this._resetLayer();
-                this._handleFlagClick(flag);
-                return;
-            }
-            
-            // Remove the selectedFlags from the end
-            for (let i = 0; i < positionToReduce; i++){
-                this.selectedFlags.at(-1).unselect();
-                this.selectedFlags.pop();
-                // remove last entry from this.selectedReachableClusters
-                this.selectedReachableClusters.pop();
-                this.currentPosition--;
-                this.path.pop();
-            }
-
-
-            // update the path and DFS from the last selected flag
-            this.polyline.setLatLngs(this.path);
-
-            if (broadcast && App.session.ws && App.session.ws.readyState === WebSocket.OPEN) {
-                let selectedFlags = [];
-                this.selectedFlags.forEach(flag => {
-                    selectedFlags.push(flag.objectName);
-                });
-                App.session.ws.send(
-                    JSON.stringify({
-                        type: "CLICK_LAYER",
-                        flag: flag.objectName,
-                        selectedFlags: selectedFlags,
-                    })
-                );
-            }
-
-            flag = this.selectedFlags.at(-1);
-        }
-        // Going forward
-        else {
-            // Add the clicked flag to the selected flags
-            flag.select();
-            this.selectedFlags.push(flag);
-            this.currentPosition++;
-            // Update the path
-            this.path.push(flag.latlng);
-            this.polyline.setLatLngs(this.path);
-
-            if (broadcast && App.session.ws && App.session.ws.readyState === WebSocket.OPEN) {
-                let selectedFlags = [];
-                this.selectedFlags.forEach(flag => {
-                    selectedFlags.push(flag.objectName);
-                });
-                App.session.ws.send(
-                    JSON.stringify({
-                        type: "CLICK_LAYER",
-                        flag: flag.objectName,
-                        selectedFlags: selectedFlags,
-                    })
-                );
-            }
+        if (broadcast && App.session.ws && App.session.ws.readyState === WebSocket.OPEN) {
+            App.session.ws.send(
+                JSON.stringify({
+                    type: "CLICK_LAYER",
+                    flag: flag.objectName,
+                    selectedFlags: this.selectedFlags.map((f) => f.objectName),
+                })
+            );
+            console.debug(`[LAYER] Sent layer click update for flag #${flag.objectName}`);
         }
 
-        this.render(flag, false, backward);
-
+        return true;
     }
+
 
     /**
-     * For a given flag render the layer
-     * Start a DFS from the flag, hide every not-already-selected flags & show the reachable ones
-     * @param {Objectives} flag - Flag from where to start
-     * @param {boolean} preview - Should we just fade out other flags or hide them
-     * @param {boolean} backward - User is going backward (unselecting flags)
+     * Solver constraints for the confirmed flags. A flag owns several candidate ids when
+     * the randomizer offers the same point on more than one route, so each entry means
+     * "any one of these ids, at this depth".
+     * @param {SquadObjective[]} [flags] - defaults to every confirmed flag
+     * @returns {{ids: string[], step: ?number}[]}
      */
-    render(flag, preview, backward = false) {
-
-        console.debug("[LAYER] ****************************************");
-        console.debug("[LAYER]               LAYER UPDATE              ");
-        console.debug("[LAYER] ****************************************");
-        console.debug("[LAYER]   -> Preview:", preview);
-        console.debug("[LAYER]   -> Reverse:", this.reversed);
-        console.debug("[LAYER]   -> Selected Flag:", flag.objectName);
-        console.debug("[LAYER]   -> Clicked flag position", flag.position);
-        console.debug("[LAYER]   -> Current position", this.currentPosition);
-        console.debug("[LAYER]   -> Current selected Flags", this.selectedFlags);
-        console.debug("[LAYER]   -> Cluster History", this.selectedReachableClusters);
-
-        console.debug("[LAYER] ****************************************");
-        console.debug("[LAYER]                   DFS                   ");
-        console.debug("[LAYER] ****************************************");
-
-        let reachableClusters = this.getReachableClusters(flag, preview);
-        if (reachableClusters.size <= 1) return;
-
-        console.debug("[LAYER] ****************************************");
-        console.debug("[LAYER]                Rendering                ");
-        console.debug("[LAYER] ****************************************");
-
-        this.hideClusters(flag, preview);
-        let nextFlags = this.showClusters(flag, reachableClusters, preview);
-        if (!preview) {
-            // Reachable clusters just changed - refresh every flag's number/alternates label
-            // before handleNextFlags() marks the next ones and shows their percentage
-            this.flags.forEach((f) => f.update());
-            this.handleNextFlags(nextFlags, backward, reachableClusters);
-        }
-        //this.refreshLane(flag);
+    _constraints(flags = this.selectedFlags) {
+        return flags.map((flag) => ({
+            ids: flag.candidateIds,
+            step: this.confirmedStep.get(flag) ?? null,
+        }));
     }
+
+
+    /**
+     * Drop a flag's confirmation.
+     * @param {SquadObjective} flag
+     */
+    _release(flag) {
+        const at = this.selectedFlags.indexOf(flag);
+        if (at !== -1) this.selectedFlags.splice(at, 1);
+        this.confirmedStep.delete(flag);
+    }
+
+
+    /**
+     * Depth a click would confirm this flag at, or null if it cannot be confirmed now.
+     *
+     * Ordered mode, the default, only accepts the next point in the chain. With free
+     * selection on, any still-possible point can be confirmed at the shallowest depth it
+     * can occupy. Confirming the points before it pins it deeper.
+     * @param {SquadObjective} flag
+     * @returns {?number}
+     */
+    _stepForClick(flag) {
+        const options = this._stepOptionsFor(flag);
+        if (App.userSettings.freePointSelection) return options[0] ?? null;
+        return options.includes(this.nextStep) ? this.nextStep : null;
+    }
+
+
+    /**
+     * Depths a flag could still be pinned to, ignoring its own current confirmation.
+     * @param {SquadObjective} flag
+     * @returns {number[]} sorted, empty if the other confirmations already rule it out
+     */
+    _stepOptionsFor(flag) {
+        const others = this.selectedFlags.filter((other) => other !== flag);
+        const result = this.solver.solve(this._constraints(others), this.countFromEnd);
+        const steps = new Set();
+        flag.candidateIds.forEach((id) => result.byId.get(id)?.steps.forEach((step) => steps.add(step)));
+        return [...steps].sort((a, b) => a - b);
+    }
+
+
+    /**
+     * Recalculate the board from the confirmed set and paint it.
+     * @param {SquadObjective} [previewFlag] - painted as if confirmed, without confirming it
+     */
+    _renderFromSolver(previewFlag = null) {
+
+        if (!this.solver?.ok) return;
+
+        const constraints = this._constraints();
+
+        if (previewFlag) {
+            // Preview what clicking would do, including the depth it would pin.
+            const step = this._stepForClick(previewFlag);
+            if (step == null) return;
+            constraints.push({ ids: previewFlag.candidateIds, step });
+        }
+
+        const result = this.solver.solve(constraints, this.countFromEnd);
+        if (previewFlag && !result.alive) return;
+
+        this.solverResult = result;
+
+        // Shallowest step not yet pinned. Flags that can fill it are marked "next".
+        const confirmedSteps = new Set();
+        this.selectedFlags.forEach((flag) => flag.solverSteps().forEach((step) => confirmedSteps.add(step)));
+        let nextStep = 1;
+        while (confirmedSteps.has(nextStep)) nextStep++;
+        this.nextStep = nextStep;
+
+        this.flags.forEach((flag) => flag.applySolverResult(previewFlag !== null));
+
+        if (previewFlag === null) this._drawPath();
+    }
+
+
+    /**
+     * The main flag a route graph node id refers to. Links address mains by
+     * objectDisplayName, so match that first.
+     * @param {string} node
+     * @returns {SquadObjective|undefined}
+     */
+    _mainForNode(node) {
+        if (!node) return undefined;
+        return this.mains.find(
+            (main) => (main.objCluster.objectDisplayName ?? main.objectName) === node
+        );
+    }
+
+
+    /**
+     * Draw the chain through the confirmed points.
+     *
+     * Only points next to each other in the chain are joined. Knowing the first and the
+     * last point says nothing about the route between them, so a single line across the
+     * map would show a path that has not been confirmed. Each run of adjacent points
+     * becomes its own polyline, which also keeps the distance labels on confirmed legs.
+     */
+    _drawPath() {
+
+        this.pathLines.forEach((line) => line.removeFrom(this.activeLayerMarkers).remove());
+        this.pathLines = [];
+
+        const points = this.selectedFlags
+            .map((flag) => ({ step: flag.solverSteps()[0], latlng: flag.latlng }))
+            .filter((point) => point.step != null)
+            .sort((a, b) => a.step - b.step);
+
+        // The mains bracket the chain. The one the numbering counts from sits one step
+        // before the first capture point, the other one step after the last. The far main
+        // is joined only once the deepest point is confirmed.
+        if (points.length && this.perspectiveMain) {
+            points.unshift({ step: 0, latlng: this.perspectiveMain.latlng });
+
+            const farMain = this.mains.find((main) => main !== this.perspectiveMain);
+            if (farMain && points.some((point) => point.step === this.solver.stepCount)) {
+                points.push({ step: this.solver.stepCount + 1, latlng: farMain.latlng });
+            }
+        }
+
+        let run = [];
+        const flush = () => {
+            if (run.length > 1) this.pathLines.push(this._createPathLine(run.map((point) => point.latlng)));
+            run = [];
+        };
+
+        points.forEach((point, index) => {
+            if (index && point.step !== points[index - 1].step + 1) flush();
+            run.push(point);
+        });
+        flush();
+
+        this.path = this.pathLines.map((line) => line.getLatLngs());
+    }
+
+
+    /**
+     * One leg of the confirmed chain.
+     * @param {Array} latlngs
+     * @returns {Polyline}
+     */
+    _createPathLine(latlngs) {
+        const line = new Polyline(latlngs, {
+            color: "white",
+            opacity: this.isVisible ? 0.9 : 0,
+            showMeasurements: true,
+            measurementOptions: {
+                minPixelDistance: 50,
+                scaling: this.map.mapToGameScale,
+            }
+        }).addTo(this.activeLayerMarkers);
+
+        if (!App.userSettings.showFlagsDistance || !this.isVisible) line.hideMeasurements();
+
+        return line;
+    }
+
 
     // WIP
     refreshLane(flag) {
@@ -1075,245 +1159,15 @@ export default class SquadLayer {
 
 
     /**
-     * Return the reachable clusters
-     * @param {Objectives} flag - Flag from where to start
-     * @param {boolean} preview - Should we just fade in other flags or hide them
-     */
-    showClusters(flag, reachableClusters, preview = false){
-        
-        let nextFlags = [];
-        console.debug("[LAYER] Showing Clusters");
-
-        // Show reachable clusters
-        reachableClusters.forEach((clusterName) => {
-
-            let cluster = this.objectives[clusterName];
-
-            // If the cluster is not found directly, search for a matching displayName (mains)
-            if (!cluster) {
-                cluster = Object.values(this.objectives).find((obj) => obj.objectDisplayName === clusterName);
-            }
-
-            let position = Math.abs(this.startPosition - cluster.pointPosition);
-            if (!preview) position += 1;
-
-            // If the cluster is in front of the clicked flag, show it
-            if (position > this.currentPosition){
-                console.debug(`[LAYER]   -> ${cluster.name}`);
-                if (preview) this._fadeInCluster(cluster, flag);  
-                else this._showCluster(cluster);
-
-                // If cluster is directly in front of the clicked flag, count the next flags
-                if (Math.abs(position) === this.currentPosition+1){
-                    const futurFlags = this.flags.filter((f) => f.clusters.includes(cluster));
-                    futurFlags.forEach((flag) => {
-                        // Only add if not already in the list
-                        if (!nextFlags.includes(flag)) nextFlags.push(flag);
-                    });
-                }
-                
-            }
-        });
-
-        return nextFlags;
-    }
-
-    /**
-     * Hide Clusters in front of a given flag
-     * @param {Objectives} flag - Flag from where to start
-     * @param {boolean} preview - Should we just fade out other flags or hide them
-     */
-    hideClusters(flag, preview = false){
-        console.debug("[LAYER] Hidding Clusters");
-        Object.values(this.objectives).forEach((cluster) => {
-            // Only Hide/Fade cluster in front of us
-            if (Math.abs(this.startPosition - cluster.pointPosition)+1 >= this.currentPosition) {
-                console.debug(`[LAYER]   -> ${cluster.name}`);
-                if (!flag.clusters.some(c => c.name === cluster.objectName)) {
-                    if (preview) this._fadeOutCluster(cluster, flag);  
-                    else this._hideCluster(cluster, flag);
-                }
-            }
-        });
-    }
-
-
-    /**
-     * Return the reachable clusters
-     * @param {Objectives} flag - Flag from where to start
-     * @return {Set} Set of cluster reachable in front of the flag
-     */
-    getReachableClusters(flag, preview) {
-        let reachableClusters = new Set();
-        // Start DFS from each clicked flag clusters
-        flag.clusters.forEach((cluster) => {
-            let position = Math.abs(this.startPosition - cluster.pointPosition);
-            if (!preview) position += 1;
-            if (position == this.currentPosition){
-                // Only start DFS from clusters that are from our current position
-                const clusterName = cluster.name === "Main" ? cluster.objectDisplayName : cluster.name;
-                this.dfs(clusterName, reachableClusters);
-            }
-        });
-
-        // Something went wrong, we are in the wrong direction
-        if (reachableClusters.size === 1 && this.currentPosition === 1){
-            if (!flag.isMain) return;
-            console.debug("[LAYER] Already blocked, Trying again in the other direction");
-            this.reversed = !this.reversed;
-            reachableClusters.clear();
-            this.dfs(flag.clusters[0].objectDisplayName, reachableClusters);
-        }
-
-        // Remove clusters that were not reachable from the previous flag
-        reachableClusters = this._filterClusters(reachableClusters);
-
-        // Store the clusters in case we need to backtrack later
-        if (!preview) {
-            this.selectedReachableClusters.push(reachableClusters);
-            console.debug("[LAYER] Cluster History updated", this.selectedReachableClusters);
-        }
-        
-        return reachableClusters;
-    }
-    
-
-    /**
-     * Handle next flags behaviour
-     * Hightlight the next flags / show their % / Click the next flag if only one
-     * @param {Array} nextFlags - Array of next flags
-     * @param {boolean} backward - True if we are going backward
-     */
-    handleNextFlags(nextFlags, backward, reachableClusters) {
-
-        // Only one flag in front ? Click it adn stop here
-        if (nextFlags.length === 1 && !backward) {
-            this._handleFlagClick(nextFlags[0], false);
-            return;
-        } 
-
-        // Highlight the next flags with a proper class
-        nextFlags.forEach(flag => {
-            flag.flag._icon.classList.add("next");
-            flag.flag.options.icon.options.className = "flag flag" + flag.position + " next";
-            flag.isNext = true;
-        });
-
-
-        // Collect only reachable clusters
-        const validClusters = nextFlags
-            .flatMap(flag => flag.clusters)
-            .filter(c =>
-                reachableClusters.has(c.name) &&
-                Math.abs(this.startPosition - c.pointPosition) === this.currentPosition
-            );
-
-        // Deduplicate clusters by name
-        const uniqueClusters = [...new Map(validClusters.map(c => [c.name, c])).values()];
-
-        // Each valid cluster gets equal weight
-        const clusterWeight = uniqueClusters.length > 0 ? 100 / uniqueClusters.length : 0;
-
-        nextFlags.forEach(flag => {
-            let percentage = 0;          
-
-            // Only check reachable clusters
-            uniqueClusters.forEach(cluster => {
-
-                if (flag.clusters.some(c => c.name === cluster.name)) {
-                    // Count how many flags in this reachable cluster
-                    const flagsInCluster = nextFlags.filter(f =>
-                        f.clusters.some(c =>
-                            c.name === cluster.name &&
-                            reachableClusters.has(c.name) &&
-                            Math.abs(this.startPosition - c.pointPosition) === this.currentPosition
-                        )
-                    ).length;
-                    percentage += clusterWeight / flagsInCluster;
-                }
-            });
-
-            flag.percentage = percentage;
-            if (App.userSettings.showNextFlagsPercentages) flag.showPercentage();
-
-        });
-
-    }
-
-
-    /**
-     * Remove clusters that were not reachable from the previous position
-     * @param {Set} reachableClusters - Set of reachable clusters
-     * @returns {Array} - List of reachable clusters
-     */
-    _filterClusters(reachableClusters) {
-        if (this.selectedReachableClusters.length > 0){
-            Array.from(reachableClusters).forEach((cluster) => {
-                if (!this.selectedReachableClusters.at(-1).has(cluster)){
-                    reachableClusters.delete(cluster);
-                    console.debug("[LAYER]  -> filtered because wasn't previously reachable :", cluster);
-                }
-            });
-        }
-        console.debug("[LAYER] Reachable clusters:", Array.from(reachableClusters));
-        return reachableClusters;
-    }
-     
-     
-    /**
-     * Deep First Search to find all reachable clusters from a given cluster
-     * @param {String} clusterName 
-     * @param {Array} reachableClusters - Set to store reachable clusters
-     */
-    dfs(clusterName, reachableClusters) {
-        if (reachableClusters.has(clusterName)) return;  // If already visited, skip
-        reachableClusters.add(clusterName); // Mark this cluster as reachable)
-
-        // Sometimes links are stored in clusters, sometimes in lanes
-        const links = this.capturePoints.lanes.links || this.capturePoints.clusters.links;
-
-        // Traverse each link to find connected clusters
-        links.forEach((link) => {
-            if (this.reversed){
-                if (link.nodeB === clusterName && !reachableClusters.has(link.nodeA)) {
-                    this.dfs(link.nodeA, reachableClusters);  // Traverse from nodeB to nodeA
-                }
-            }
-            else if (link.nodeA === clusterName && !reachableClusters.has(link.nodeB)) {
-                this.dfs(link.nodeB, reachableClusters);  // Traverse from nodeA to nodeB
-            }
-        });
-    }
-
-
-    /**
-     * Unselects all flags and resets the layer
+     * Drop every confirmation and show the whole layer again.
      */
     _resetLayer() {
         console.debug("[LAYER] Resetting layer");
-
-        this.currentPosition = 0;
-        this.selectedReachableClusters = [];
         this.selectedFlags = [];
-        this.reversed = false;
-        this.path = [];
-        //this.hexs = [];
-        this.polyline.setLatLngs([]);
-
-        this.flags.forEach((flag) => {
-            flag.unselect();
-            if (!flag.isMain) flag.hide();
-        });
-
-        // Pre-select first main flag in invasion
-        if (this.gamemode === "Invasion" || this.gamemode === "RINV") {
-            this.mains.forEach((main) => {
-                if (main.objectName === this.capturePoints.clusters.listOfMains[0]){
-                    this._handleFlagClick(main, false);
-                }
-            });
-        }
+        this.confirmedStep.clear();
+        this._renderFromSolver();
     }
+
 
     /**
      * Set the opacity of the layer
@@ -1323,6 +1177,7 @@ export default class SquadLayer {
         
         // Polyline opacity
         this.polyline.setStyle({ opacity: value });
+        this.pathLines.forEach((line) => line.setStyle({ opacity: value }));
 
         // Flags opacity
         this.flags.forEach((flag) => {
@@ -1350,114 +1205,11 @@ export default class SquadLayer {
     }
 
 
-    _showCluster(cluster) {
-        if (cluster.name === "Main") return;
-
-        const flagsToShow = this.flags.filter((f) =>
-            f.clusters.includes(cluster)
-        );
-
-        flagsToShow.forEach((flagToShow) => {
-
-            const foundClusters = [];
-
-            // Filters the clusters that were reachable from the previous flag
-            flagToShow.clusters.forEach((cluster) => {
-                if (this.selectedReachableClusters.at(-1).has(cluster.name)){
-                    foundClusters.push(cluster);
-                }
-            });
-
-            let newPos;
-
-            if (this.reversed){
-                newPos = 0;
-                for (const item of foundClusters) {
-                    if (Math.abs(this.startPosition - item.pointPosition) >= this.currentPosition && item.pointPosition > newPos) {
-                        newPos = item.pointPosition;
-                    }
-                }
-            } else {
-                newPos = Infinity;
-                for (const item of foundClusters) {
-                    if (item.pointPosition > this.currentPosition && item.pointPosition < newPos) {
-                        newPos = item.pointPosition;
-                    }
-                }
-                // Something went wrong, try the opposite
-                if (newPos === Infinity){
-                    newPos = 0;
-                    for (const item of foundClusters) {
-                        if (item.pointPosition <= this.currentPosition && item.pointPosition > newPos) {
-                            newPos = item.pointPosition;
-                        }
-                    }
-                }
-            }
-            flagToShow.position = newPos;
-            flagToShow.show();
-        });
-
-    }
-
-    _hideCluster(cluster, clickedFlag) {
-
-        if (cluster.name === "Main") return;
-
-        const flagsToHide = this.flags.filter((f) =>
-            f !== clickedFlag && f.clusters.includes(cluster)
-        );
-
-        // Show each flag that was found
-        flagsToHide.forEach((flagToHide) => {
-            if (!this.selectedFlags.includes(flagToHide)){
-                flagToHide.hide();
-            }
-        });
-    }
-
-    _fadeInCluster(cluster, clickedFlag) {
-
-        if (cluster.name === "Main") return;
-
-        const flagsToHide = this.flags.filter((f) =>
-            f !== clickedFlag && f.clusters.includes(cluster)
-        );
-
-        // Show each flag that was found
-        flagsToHide.forEach((flagToHide) => {
-            if (!this.selectedFlags.includes(flagToHide)){
-                flagToHide._fadeIn();
-                if (!App.userSettings.capZoneOnHover) {
-                    if (this.map.getZoom() > this.map.detailedZoomThreshold){
-                        flagToHide.revealCapZones();
-                    }
-                }
-            }
-        });
-    }
-
-    _fadeOutCluster(cluster, clickedFlag) {
-
-        if (cluster.name === "Main") return;
-
-        const flagsToHide = this.flags.filter((f) =>
-            f !== clickedFlag && f.clusters.includes(cluster)
-        );
-
-        // Show each flag that was found
-        flagsToHide.forEach((flagToHide) => {
-            if (!this.selectedFlags.includes(flagToHide)){
-                flagToHide._fadeOut();
-                flagToHide.hideCapZones();
-            }
-        });
-    }
-
     toggleVisibility() {
         if (this.isVisible) {
             this._setOpacity(0);
             this.polyline.hideMeasurements();
+            this.pathLines.forEach((line) => line.hideMeasurements());
             this.isVisible = false;
             $(".btn-layer").removeClass("active");
             this.hideAllCapzones();
@@ -1473,10 +1225,9 @@ export default class SquadLayer {
             this._setOpacity(1);
             this.setMainZoneOpacity(true);
             if (App.userSettings.showFlagsDistance) {
-                this.polyline.showMeasurements({
-                    minPixelDistance: 50,
-                    scaling: this.map.mapToGameScale,
-                });
+                const measurementOptions = { minPixelDistance: 50, scaling: this.map.mapToGameScale };
+                this.polyline.showMeasurements(measurementOptions);
+                this.pathLines.forEach((line) => line.showMeasurements(measurementOptions));
             }
             $(".btn-layer").addClass("active");
             this.isVisible = true;
@@ -1518,6 +1269,9 @@ export default class SquadLayer {
         this.vehicleSpawners = [];
         this.hexs = [];
         this.stagingZones = [];
+        this.selectedFlags = [];
+        this.confirmedStep.clear();
+        this.solverResult = null;
     }
 
 }

--- a/src/js/squadObjective.js
+++ b/src/js/squadObjective.js
@@ -22,6 +22,11 @@ export class SquadObjective {
         this.layer = layer;
         this.latlng = latlng;
         this.clusters = [];
+
+        // Every candidate slot this flag occupies, by point objectName. The randomizer can
+        // offer the same capture zone on several routes and at several depths. objectName is
+        // unique per layer, name is not, so the solver identifies points by it.
+        this.candidateIds = [];
         this.capZones = new LayerGroup();
         this.isMain = isMain;
         this.isHidden = false;
@@ -62,7 +67,7 @@ export class SquadObjective {
         });
 
         this.flag = new Marker(latlng, {icon : tempIcon}).addTo(this.layerGroup);
-        this.addCluster(cluster);
+        this.addCluster(cluster, objCluster);
         this.updateMainIcon();
 
         this.flag.on("click", this._handleClick, this);
@@ -122,7 +127,6 @@ export class SquadObjective {
 
 
     select(){
-        let position;
         let html = "";
         let className = "flag selected";
         this.isNext = false;
@@ -133,9 +137,8 @@ export class SquadObjective {
         if (this.isMain) {
             className += " main";
         } else {
-            position = Math.abs(this.layer.startPosition - this.position);
-            const positions = this._reachableAlternatePositions().map(p => Math.abs(this.layer.startPosition - p)).sort((a, b) => a - b);
-            html = positions.length > 1 ? positions.join("·") : position;
+            const positions = this.solverSteps();
+            html = positions.length > 1 ? positions.join("·") : (positions[0] ?? "");
             if (positions.length > 1) className += positions.length > 2 ? " multiPos multiPosMany" : " multiPos";
         }
 
@@ -312,30 +315,25 @@ export class SquadObjective {
 
     unselect(){
         let html = "";
-        let position = Math.abs(this.layer.startPosition - this.position);
         let className = "flag";
+        const positions = this.layer.isRandomized ? this.solverSteps() : [];
 
         if (App.userSettings.circlesFlags) className += " circleFlag";
 
         if (this.isMain) {
-            if (this.layer.gamemode === "RAAS" || this.layer.gamemode === "RVAAS"){
-                className += " main selectable";
-            } else {
-                className += " main unselectable";
-            }
+            className += this.layer.isRandomized ? " main selectable" : " main unselectable";
         } else {
-            if (this.layer.isRandomized){
-                const positions = this._reachableAlternatePositions().map(p => Math.abs(this.layer.startPosition - p)).sort((a, b) => a - b);
-                html = positions.length > 1 ? positions.join("·") : position;
-                className += " flag" + position;
+            if (this.layer.isRandomized && positions.length){
+                html = positions.length > 1 ? positions.join("·") : positions[0];
+                className += " flag" + positions[0];
                 if (positions.length > 1) className += positions.length > 2 ? " multiPos multiPosMany" : " multiPos";
             }
         }
 
-        if (Math.abs(this.layer.startPosition - this.position) === this.layer.currentPosition){
-            if (this.layer.isRandomized){
-                className += " next";
-            }
+        // "Next" is the shallowest depth still unconfirmed.
+        if (this.layer.isRandomized && positions.includes(this.layer.nextStep)){
+            className += " next";
+            this.isNext = true;
         } else this.isNext = false;
 
         this.flag.removeFrom(this.layerGroup).remove();
@@ -354,88 +352,126 @@ export class SquadObjective {
 
     
     /**
-     * Find every cluster (lane) that has a point at this flag's physical
-     * location - the RAAS randomizer can offer the same real-world capture zone
-     * as a candidate at more than one lane depth. Matching by name alone is
-     * wrong: maps can reuse a generic label (e.g. "Forest") for entirely
-     * unrelated spots that just happen to be named the same. A small tolerance
-     * absorbs float rounding between the two copies of the same point (e.g.
-     * -232245.875 vs -232245.890625).
-     * @returns {object[]} clusters with a matching point
+     * Attach one more cluster (lane slot) that offers this same physical point.
+     * @param {object} cluster - the capture-zone cluster
+     * @param {object} [point] - the candidate inside that cluster. Its objectName identifies the slot.
      */
-    _alternateClusters() {
-        const { location_x, location_y } = this.objCluster;
-        const tolerance = 1;
-        return Object.values(this.layer.objectives).filter(
-            (c) => c.points && c.points.some((p) =>
-                Math.abs(p.location_x - location_x) < tolerance && Math.abs(p.location_y - location_y) < tolerance
-            )
-        );
-    }
-
-
-    /**
-     * Distinct pointPositions where this flag's name still has a reachable
-     * alternate - dropped once its own cluster (lane) is no longer part of
-     * the layer's live reachable-clusters set (branch eliminated, or the
-     * step itself already passed).
-     * @returns {number[]} sorted distinct reachable pointPositions
-     */
-    _reachableAlternatePositions() {
-        const reachable = this.layer.selectedReachableClusters.at(-1);
-        // A cluster can hold several mutually-exclusive names in the same slot
-        // (e.g. "Pipeline" or "Paseka" both live in the same cluster) - once a
-        // flag has actually been clicked, its own cluster(s) are locked to that
-        // outcome and no longer count as an alternate for any other name.
-        const consumedClusters = new Set(this.layer.selectedFlags.flatMap((f) => f.clusters));
-        return [...new Set(
-            this._alternateClusters()
-                .filter((c) => !reachable || reachable.has(c.name))
-                .filter((c) => !consumedClusters.has(c))
-                .map((c) => c.pointPosition)
-        )].sort((a, b) => a - b);
-    }
-
-
-    addCluster(cluster){
+    addCluster(cluster, point){
         this.clusters.push(cluster);
+        if (point?.objectName && !this.candidateIds.includes(point.objectName)) {
+            this.candidateIds.push(point.objectName);
+        }
         this.updatePosition();
     }
 
 
+    /**
+     * This flag's state in the layer's latest solve.
+     * @returns {{steps: number[], probability: number}} depths where it is still possible
+     *          (1 = first point after the main), and the chance it is on the route
+     */
+    solverInfo(){
+        const result = this.layer.solverResult;
+        const steps = new Set();
+        let probability = 0;
+
+        if (result) {
+            this.candidateIds.forEach((id) => {
+                const entry = result.byId.get(id);
+                if (!entry) return;
+                entry.steps.forEach((step) => steps.add(step));
+                probability += entry.probability;
+            });
+        }
+
+        return { steps: [...steps].sort((a, b) => a - b), probability };
+    }
+
+
+    /**
+     * Depths where this flag is still possible.
+     * @returns {number[]}
+     */
+    solverSteps(){
+        return this.solverInfo().steps;
+    }
+
+
+    /**
+     * Repaint this flag from the layer's latest solve: hidden when no longer possible,
+     * selected when confirmed, otherwise numbered with its remaining depths.
+     * @param {boolean} preview - hover preview, so fade instead of rebuilding
+     */
+    applySolverResult(preview = false){
+
+        if (this.isMain) {
+            // Mains carry no candidates. They only show which side the depths count from.
+            if (preview) return;
+            if (this === this.layer.perspectiveMain) this.select();
+            else this.unselect();
+            return;
+        }
+
+        const { steps, probability } = this.solverInfo();
+
+        if (preview) {
+            if (steps.length) { if (this.isFadeOut) this._fadeIn(); }
+            else this._fadeOut();
+            return;
+        }
+
+        if (!steps.length) {
+            if (!this.isHidden) this.hide();
+            return;
+        }
+
+        if (this.isHidden) this.show();
+
+        if (this.layer.selectedFlags.includes(this)) {
+            this.select();
+            return;
+        }
+
+        this.unselect();
+
+        // Shown for every still-possible point, not only the next one. A point that has
+        // become certain shows 100%.
+        if (App.userSettings.showNextFlagsPercentages) {
+            this.percentage = probability * 100;
+            this.showPercentage();
+        }
+    }
+
+
+    /**
+     * Refresh this flag's icon. The depth label comes from the solver, which does not
+     * exist yet during construction, so the flag starts unnumbered and the layer paints
+     * it after init().
+     */
     updatePosition() {
 
-        let lowestPossiblePosition;
         let className = "flag";
         let html = "";
+        const positions = this.layer.isRandomized ? this.solverSteps() : [];
 
-        if (this.layer.reversed) {
-            lowestPossiblePosition = this.clusters.reduce((max, item) => {
-                return item.pointPosition - 1 > max ? item.pointPosition : max;
-            }, this.clusters[0].pointPosition);
-        } else {
-            lowestPossiblePosition = this.clusters.reduce((min, item) => {
-                return item.pointPosition < min ? item.pointPosition : min;
-            }, this.clusters[0].pointPosition);
-        }
-        
-        this.position = lowestPossiblePosition;
-    
+        // Shallowest remaining depth, or the raw cluster data before the first solve.
+        // Only used for the colour class.
+        this.position = positions[0] ?? this.clusters.reduce(
+            (min, item) => (item.pointPosition != null && item.pointPosition < min ? item.pointPosition : min),
+            Infinity
+        );
+        if (!Number.isFinite(this.position)) this.position = 0;
+
         if (App.userSettings.circlesFlags){
             className += " circleFlag";
         }
 
-        if (this.isMain) { 
-            if (this.layer.gamemode === "RAAS" || this.layer.gamemode === "RVAAS") className += " main selectable";
-            else className += " main unselectable";
-        } else {
-            // if RAAS/Invasion, add the flag number and a colored icon
-            if (this.layer.isRandomized) {
-                className += " flag" + this.position;
-                const positions = this._reachableAlternatePositions();
-                html = positions.length > 1 ? positions.join("·") : this.position;
-                if (positions.length > 1) className += positions.length > 2 ? " multiPos multiPosMany" : " multiPos";
-            }
+        if (this.isMain) {
+            className += this.layer.isRandomized ? " main selectable" : " main unselectable";
+        } else if (this.layer.isRandomized && positions.length) {
+            className += " flag" + positions[0];
+            html = positions.length > 1 ? positions.join("·") : positions[0];
+            if (positions.length > 1) className += positions.length > 2 ? " multiPos multiPosMany" : " multiPos";
         }
 
         // Refresh the flag icon
@@ -446,6 +482,7 @@ export class SquadObjective {
             iconAnchor: [22, 11]
         }));
     }
+
 
     _handleClick(){
         clearTimeout(this.mouseOverTimeout);
@@ -473,9 +510,11 @@ export class SquadObjective {
 
         // On RAAS/Invasion, preview the lane on hover
         if (this.layer.isRandomized) {
-            if (this.isNext && App.userSettings.revealLayerOnHover) {
+            // In ordered mode only the next point can be clicked, so preview only that one.
+            const clickable = App.userSettings.freePointSelection || this.isNext;
+            if (clickable && !this.isSelected && !this.isHidden && App.userSettings.revealLayerOnHover) {
                 this.mouseOverTimeout = setTimeout(() => {
-                    this.layer.render(this, true);
+                    this.layer._renderFromSolver(this);
                 }, 250);
             }
         }

--- a/src/js/squadSettings.js
+++ b/src/js/squadSettings.js
@@ -259,6 +259,16 @@ export default class SquadSettings {
                 default: true,
                 selector: "#revealLayerOnHoverSettings"
             },
+            freePointSelection: {
+                key: "settings-free-point-selection",
+                default: false,
+                selector: "#freePointSelectionSettings",
+                onChange: () => {
+                    // Confirmations made out of order cannot survive a switch to ordered
+                    // mode, so reset the layer either way.
+                    if (this.app.minimap.layer?.solver?.ok) this.app.minimap.layer._resetLayer();
+                }
+            },
             capZoneOnHover: {
                 key: "settings-capZone-onHover",
                 default: false,


### PR DESCRIPTION
## What this does

Lets a capture point be confirmed anywhere in the chain instead of only the next one, behind a setting that is off by default.

On Narva RAAS v1: confirming Farmstead forces the enemy's first point to Parusinka. Confirming Kiriku after it removes Quarry and Fuel Storage. Confirming Kiriku on its own narrows the first point down to Abandoned Airfield or Farmstead.

## Setting

`Allow selecting points in any order`, under Layers Options, off by default. With it off, points are confirmed in order as before.

## How it works

New module `src/js/squadLaneSolver.js` enumerates the layer's routes once and treats each confirmed point as a constraint, dropping every route that cannot carry it at that depth. This replaces the forward DFS walk, so `startPosition`, `currentPosition`, `reversed` and `selectedReachableClusters` are gone.

Points are identified by `objectName` rather than `name`, because 16 of the 42 layers I checked reuse a display name for two unrelated locations.

## Also changed

- The chain line only joins points that are adjacent in the chain
- Percentages show for every possible point, not only the next ones

